### PR TITLE
Set OS_CLOUD env var when creating OS resources

### DIFF
--- a/roles/bootstrap/tasks/in_zuul.yml
+++ b/roles/bootstrap/tasks/in_zuul.yml
@@ -67,6 +67,8 @@
       - "openstacksdk"
 
 - name: Create the crc based CI environment
+  environment:
+    OS_CLOUD: "{{ cifmw_bootstrap_cloud_name }}"
   block:
     - name: Write file
       ansible.builtin.template:


### PR DESCRIPTION
When cloud name is different from "default", we need to set OS_CLOUD env var, so openstack commands pick the correct auth configuration.