### PR TITLE
Move application credentials keys dict level

### DIFF
--- a/roles/bootstrap/templates/clouds.yaml.j2
+++ b/roles/bootstrap/templates/clouds.yaml.j2
@@ -6,8 +6,8 @@ clouds:
  "applicationcredential" in cloud_secrets[ cifmw_bootstrap_cloud_name ].auth_type %}
     auth:
         auth_url: {{ cloud_secrets[ cifmw_bootstrap_cloud_name ].auth_url }}
-        application_credential_id: {{ cloud_secrets[ cifmw_bootstrap_cloud_name ].auth.application_credential_id }}
-        application_credential_secret: {{ cloud_secrets[ cifmw_bootstrap_cloud_name ].auth.application_credential_secret }}
+        application_credential_id: {{ cloud_secrets[ cifmw_bootstrap_cloud_name ].application_credential_id }}
+        application_credential_secret: {{ cloud_secrets[ cifmw_bootstrap_cloud_name ].application_credential_secret }}
     auth_type: "v3applicationcredential"
 {% elif cloud_secrets[ cifmw_bootstrap_cloud_name ].password is defined %}
     auth:


### PR DESCRIPTION
This patch moves application_credential_id and application_credential_secret to the same level as auth_url, to keep secrets simple.