### PR TITLE
Add an opcional var to override application cred id

### DIFF
--- a/roles/bootstrap/templates/clouds.yaml.j2
+++ b/roles/bootstrap/templates/clouds.yaml.j2
@@ -6,7 +6,7 @@ clouds:
  "applicationcredential" in cloud_secrets[ cifmw_bootstrap_cloud_name ].auth_type %}
     auth:
         auth_url: {{ cloud_secrets[ cifmw_bootstrap_cloud_name ].auth_url }}
-        application_credential_id: {{ cloud_secrets[ cifmw_bootstrap_cloud_name ].application_credential_id }}
+        application_credential_id: {{ application_credential_id_override|default(cloud_secrets[ cifmw_bootstrap_cloud_name ].application_credential_id) }}
         application_credential_secret: {{ cloud_secrets[ cifmw_bootstrap_cloud_name ].application_credential_secret }}
     auth_type: "v3applicationcredential"
 {% elif cloud_secrets[ cifmw_bootstrap_cloud_name ].password is defined %}


### PR DESCRIPTION
With this option, jobs can override application cred id. With that, we can replace application credentials, since secrets can be set at app credentials creation.