### PR TITLE
Add reconfigure kubelet plays

### DIFF
--- a/roles/bootstrap/tasks/in_zuul.yml
+++ b/roles/bootstrap/tasks/in_zuul.yml
@@ -135,3 +135,15 @@
       ansible.builtin.file:
         path: "{{ ansible_user_dir }}/.config/openstack/clouds.yaml"
         state: absent
+
+- hosts: crc
+  tasks:
+    - name: Reconfigure kubelet service
+      ansible.builtin.include_tasks: reconfigure-kubelet.yaml
+
+    - name: Reboot host after kubelet is reconfigured
+      become: true
+      ansible.builtin.reboot:
+
+    - include_role:
+        name: start-zuul-console

--- a/roles/bootstrap/tasks/reconfigure-kubelet.yaml
+++ b/roles/bootstrap/tasks/reconfigure-kubelet.yaml
@@ -1,0 +1,40 @@
+---
+# Currently, the CRC is using:
+# --system-reserved=cpu=200m,memory=350Mi,ephemeral-storage=350Mi
+# Which means:
+# - SYSTEM_RESERVED_CPU = 200m
+# - SYSTEM_RESERVED_MEMORY = 350Mi
+# - SYSTEM_RESERVED_ES = 350Mi
+# Which might be not enough for basic services on high utilized worker node.
+# Those values are set in /etc/node-sizing.env (base on kubelet service file)
+# with values: https://github.com/crc-org/snc/blob/release-4.12/node-sizing-enabled.env
+# Helpful doc: https://docs.openshift.com/container-platform/4.12/nodes/nodes/nodes-nodes-resources-configuring.html
+- name: Change the kubelet service EnvironmentFile
+  become: true
+  ansible.builtin.lineinfile:
+    path: /etc/node-sizing.env
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+  loop:
+    - regexp: "^SYSTEM_RESERVED_CPU=200m"
+      line: "SYSTEM_RESERVED_CPU={{ bootstrap_ci_crc_systemd_cpu | default('800m') }}"
+    - regexp: "^SYSTEM_RESERVED_MEMORY=350Mi"
+      line: "SYSTEM_RESERVED_MEMORY={{ bootstrap_ci_crc_systemd_mem | default('700Mi') }}"
+    - regexp: "^SYSTEM_RESERVED_ES=350Mi"
+      line: "SYSTEM_RESERVED_ES={{ bootstrap_ci_crc_systemd_disk | default('700Mi') }}"
+
+- name: Change the kubelet sizing enabled
+  become: true
+  ansible.builtin.lineinfile:
+    path: /etc/node-sizing-enabled.env
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+  loop:
+    - regexp: "^SYSTEM_RESERVED_CPU=200m"
+      line: "SYSTEM_RESERVED_CPU={{ bootstrap_ci_crc_systemd_cpu | default('800m') }}"
+    - regexp: "^SYSTEM_RESERVED_MEMORY=350Mi"
+      line: "SYSTEM_RESERVED_MEMORY={{ bootstrap_ci_crc_systemd_mem | default('700Mi') }}"
+    - regexp: "^SYSTEM_RESERVED_ES=350Mi"
+      line: "SYSTEM_RESERVED_ES={{ bootstrap_ci_crc_systemd_disk | default('700Mi') }}"
+    - regexp: "^NODE_SIZING_ENABLED=false"
+      line: "NODE_SIZING_ENABLED={{ bootstrap_ci_crc_systemd_autosizing | default('false') }}"


### PR DESCRIPTION
This patch adds the reconfigure kubelet pieces, which increase the reserved memory for this service.
Note that this tasks can be moved to ci-framework afterwards if needed.