### PR TITLE
Remove openstacksdk version restriction

### DIFF
--- a/roles/bootstrap/tasks/in_zuul.yml
+++ b/roles/bootstrap/tasks/in_zuul.yml
@@ -57,7 +57,8 @@
     name:
       - "virtualenv"
       - "python-openstackclient"
-      - "openstacksdk>=0.36,<0.99.0"
+      - "openstacksdk"
+      # - "openstacksdk>=0.36,<0.99.0"
 
 - name: Install required packages
   ansible.builtin.pip:


### PR DESCRIPTION
The ansible collection installed for openstack cloud is needs openstacksdk>=1.0.0