### PR TITLE
Remove openstacksdk after finishing plays

### DIFF
--- a/roles/bootstrap/tasks/cleanup_networking.yml
+++ b/roles/bootstrap/tasks/cleanup_networking.yml
@@ -20,6 +20,10 @@
     state: directory
     mode: '0755'
 
+- name: Make sure that we have the expected openstacksdk
+  ansible.builtin.pip:
+    name: "openstacksdk>=0.36,<0.99.0"
+
 - name: Check for cleanup skip flag file presence
   ansible.builtin.stat:
     path: "{{ ansible_user_dir }}/crc-ci-bootstrap-skip-cleanup"

--- a/roles/bootstrap/tasks/in_zuul.yml
+++ b/roles/bootstrap/tasks/in_zuul.yml
@@ -52,18 +52,12 @@
       - python3-pip
     state: present
 
-- name: Install collection openstack.cloud
-  community.general.ansible_galaxy_install:
-    type: collection
-    name: openstack.cloud
-
 - name: Install required packages
   ansible.builtin.pip:
     name:
       - "virtualenv"
       - "python-openstackclient"
-      - "openstacksdk"
-      # - "openstacksdk>=0.36,<0.99.0"
+      - "openstacksdk>=0.36,<0.99.0"
 
 - name: Install required packages
   ansible.builtin.pip:
@@ -140,4 +134,9 @@
     - name: Remove cloud_secrets file
       ansible.builtin.file:
         path: "{{ ansible_user_dir }}/.config/openstack/clouds.yaml"
+        state: absent
+
+    - name: Remove openstacksdk to avoid conflicts
+      ansible.builtin.pip:
+        name: openstacksdk
         state: absent


### PR DESCRIPTION
The opentack collection installed in the executor is older and needs an specific version of openstacksdk installed. Since this will conflict with future task, we will remove after finishing all plays. When calling cleanup, we should guarantee that the expected version is installed again.