### PR TITLE
Adds NM configuration to nodes

### DIFF
--- a/roles/bootstrap/tasks/create-attach-port.yml
+++ b/roles/bootstrap/tasks/create-attach-port.yml
@@ -168,3 +168,58 @@
       loop_control:
         label: "{{ instance_net_item.key }}"
         loop_var: instance_net_item
+
+    - name: Prepare VLANs interface data to be used configuring
+      vars:
+        network_config: "{{ crc_ci_bootstrap_networking.networks[instance_net_item.key] }}"
+        parent_net_info: "{{ crc_ci_bootstrap_networks_out[instance_item.key]['default'] }}"
+        iface_mac: >-
+          {{
+            '52:54:00' |
+            community.general.random_mac(
+              seed=(
+                  (crc_ci_bootstrap_instance_parent_port_create_yaml.port.mac_address | lower) +
+                  (network_config.vlan | string)
+                )
+            ) | lower
+          }}
+        iface_name: "{{ parent_net_info.iface + '.' + (network_config.vlan | string) }}"
+        # VLAN iface MTU is the parent MTU minus the 802.1Q header size
+        iface_mtu: "{{ parent_net_info.mtu | int - 4 }}"
+        ip_with_prefix: >-
+          {{
+            instance_net_item.value.ip + "/" +
+            (network_config.range | ansible.utils.ipaddr('prefix') | string)
+          }}
+        iface_connection_name: "{{ 'ci-private-network-' + (network_config.vlan | string) }}"
+      ansible.builtin.set_fact:
+        crc_ci_bootstrap_networks_out: >-
+          {{
+            crc_ci_bootstrap_networks_out |
+            combine(
+              {
+                instance_item.key: {
+                  instance_net_item.key: {
+                    'iface': iface_name,
+                    'vlan': network_config.vlan,
+                    'parent_iface': parent_net_info.iface,
+                    'connection':
+                      (
+                        iface_connection_name
+                        if (instance_net_item.value.config_nm | default(true) | bool)
+                        else omit
+                      ),
+                    'mac': iface_mac,
+                    'mtu': iface_mtu,
+                    'ip': ip_with_prefix,
+                    'dns': network_config.dns | default(omit),
+                  }
+                }
+              }, recursive=true)
+
+          }}
+        cacheable: true
+      loop: "{{ crc_ci_bootstrap_instance_nm_vlan_networks }}"
+      loop_control:
+        label: "{{ instance_net_item.key }}"
+        loop_var: instance_net_item

--- a/roles/bootstrap/tasks/create-default-resources.yml
+++ b/roles/bootstrap/tasks/create-default-resources.yml
@@ -28,6 +28,7 @@
     network_name: "{{ crc_ci_bootstrap_private_net_create_out.network.id }}"
     name: "{{ crc_ci_bootstrap_subnet_name }}"
     cidr: "{{ default_network_config.range }}"
+    is_dhcp_enabled: false
   register: crc_ci_bootstrap_private_subnet_create_out
 
 - name: Set yaml returned data for further usage

--- a/roles/bootstrap/tasks/in_zuul.yml
+++ b/roles/bootstrap/tasks/in_zuul.yml
@@ -90,6 +90,43 @@
         label: "{{ instance_item.key }}"
         loop_var: instance_item
 
+    - name: Apply Network Manager changes in the target instance
+      delegate_to: "{{ instance_item.key }}"
+      block:
+        - name: Create NetworkManager configuration file for the trunk port
+          vars:
+            iface_info: "{{ item.value }}"
+          become: true
+          when: "iface_info.connection is defined and iface_info.connection != ''"
+          ansible.builtin.template:
+            src: >-
+              {{
+                'bootstrap-ci-network-vlan-nm-connection.nmconnection.j2'
+                if ('vlan' in iface_info) else 'bootstrap-ci-network-nm-connection.nmconnection.j2'
+              }}
+            dest: "/etc/NetworkManager/system-connections/{{ iface_info.connection }}.nmconnection"
+            mode: '0600'
+            owner: root
+            group: root
+          loop: "{{ crc_ci_bootstrap_networks_out[instance_item.key] | dict2items }}"
+          loop_control:
+            label: "{{ item.key }}"
+
+        - name: Refresh NetworkManager
+          become: true
+          ansible.builtin.systemd:
+            name: NetworkManager
+            state: restarted
+
+        - name: Debug fetch IP routes
+          register: crc_ci_bootstrap_host_routes_out
+          ansible.builtin.command:
+            cmd: "ip route"
+
+        - name: Debug IP routes
+          ansible.builtin.debug:
+            var: crc_ci_bootstrap_host_routes_out
+
     - name: Display some data about network ports
       ansible.builtin.command:
         cmd: "openstack port list --network {{ crc_ci_bootstrap_network_name }}"

--- a/roles/bootstrap/templates/bootstrap-ci-network-nm-connection.nmconnection.j2
+++ b/roles/bootstrap/templates/bootstrap-ci-network-nm-connection.nmconnection.j2
@@ -1,0 +1,25 @@
+[connection]
+id={{ iface_info.connection }}
+uuid={{ 99999999 | random | to_uuid }}
+type=ethernet
+autoconnect=true
+
+[ethernet]
+mac-address={{ iface_info.mac | trim | lower }}
+mtu={{ iface_info.mtu }}
+
+[ipv4]
+method=manual
+addresses={{ iface_info.ip }}
+{% if iface_info.gw is defined and iface_info.gw != '' -%}
+gateway={{ iface_info.gw }}
+{% endif -%}
+{% if iface_info.dns is defined and iface_info.dns | length > 0 -%}
+dns={{ (iface_info.dns | join(";")) + ";" }}
+{% endif -%}
+
+[ipv6]
+addr-gen-mode=stable-privacy
+method=disabled
+
+[proxy]

--- a/roles/bootstrap/templates/bootstrap-ci-network-vlan-nm-connection.nmconnection.j2
+++ b/roles/bootstrap/templates/bootstrap-ci-network-vlan-nm-connection.nmconnection.j2
@@ -1,0 +1,30 @@
+[connection]
+id={{ iface_info.connection }}
+uuid={{ 99999999 | random | to_uuid }}
+type=vlan
+autoconnect=true
+
+[ethernet]
+cloned-mac-address={{ iface_info.mac | trim | lower }}
+mtu={{ iface_info.mtu }}
+
+[vlan]
+flags=1
+id={{ iface_info.vlan }}
+parent={{ iface_info.parent_iface }}
+
+[ipv4]
+method=manual
+addresses={{ iface_info.ip }}
+{% if iface_info.gw is defined and iface_info.gw != '' -%}
+gateway={{ iface_info.gw }}
+{% endif -%}
+{% if iface_info.dns is defined and iface_info.dns | length > 0 -%}
+dns={{ (iface_info.dns | join(";")) + ";" }}
+{% endif -%}
+
+[ipv6]
+addr-gen-mode=stable-privacy
+method=disabled
+
+[proxy]


### PR DESCRIPTION
We need to add NM configurations for all interfaces, in order to survive to reboots. This patch adds missing parts needed for NM configurations.
This patch updates subnet creation task to always disable DHCP.