### PR TITLE
Adapt bootstrap role for network env definition

### DIFF
--- a/roles/bootstrap/defaults/main.yml
+++ b/roles/bootstrap/defaults/main.yml
@@ -21,56 +21,16 @@
 cifmw_bootstrap_instance_network_name: "ci-net-test"
 cifmw_bootstrap_instance_subnet_name: "ci-subnet-test"
 cifmw_bootstrap_instance_router_name: "ci-subnet-router-test"
+cifmw_bootstrap_network_default_router_net: "public"
 cifmw_bootstrap_public_key_file: "{{ ansible_user_dir }}/.ssh/id_ed25519.pub"
 cifmw_bootstrap_keypair_name: "{{ ansible_env.USER }}-key"
 cifmw_bootstrap_clouds_yaml: "{{ ansible_user_dir }}/.config/openstack/clouds.yaml"
 cifmw_bootstrap_security_group_name: "ssh_icmp"
 cifmw_bootstrap_venv_dir: "{{ ansible_user_dir }}/bootstrap-venv"
 
-crc_ci_bootstrap_networking:
-  networks:
-    default:
-      mtu: 1500
-      range: 192.168.122.0/24
-    internal-api:
-      vlan: 20
-      range: 172.17.0.0/24
-    storage:
-      vlan: 21
-      range: 172.18.0.0/24
-    tenant:
-      vlan: 22
-      range: 172.19.0.0/24
-  instances:
-    controller:
-      networks:
-        default:
-          ip: 192.168.122.11
-    crc:
-      networks:
-        default:
-          ip: 192.168.122.10
-        internal-api:
-          ip: 172.17.0.5
-        storage:
-          ip: 172.18.0.5
-        tenant:
-          ip: 172.19.0.5
-    compute-0:
-      networks:
-        default:
-          ip: 192.168.122.100
-        internal-api:
-          ip: 172.17.0.100
-          config_nm: false
-        storage:
-          ip: 172.18.0.100
-          config_nm: false
-        tenant:
-          ip: 172.19.0.100
-          config_nm: false
-
-
 cifmw_bootstrap_openstack_cmd_retries_value: "{{ crc_ci_bootstrap_openstack_cmd_retries | default(10) }}"
 cifmw_bootstrap_openstack_cmd_delay_value: "{{ crc_ci_bootstrap_openstack_cmd_delay | default(5) }}"
 cifmw_bootstrap_pause_max_value: "{{ crc_ci_bootstrap_pause_max | default(3) }}"
+
+cifmw_bootstrap_ci_infra_dir: "/etc/ci/env"
+cifmw_bootstrap_net_env_def_path: "{{ cifmw_bootstrap_ci_infra_dir }}/networking-environment-definition.yml"

--- a/roles/bootstrap/tasks/cleanup_networking.yml
+++ b/roles/bootstrap/tasks/cleanup_networking.yml
@@ -14,6 +14,20 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Load network environment definition from file
+  when: "crc_ci_bootstrap_networking is not defined"
+  block:
+    - name: Check for network environment definition file
+      ansible.builtin.stat:
+        path: "{{ cifmw_bootstrap_net_env_def_path }}"
+      register: _net_env_file_stat
+
+    - name: Load network info from file
+      when: "_net_env_file_stat.stat.exists"
+      ansible.builtin.include_vars:
+        file: "{{ cifmw_bootstrap_net_env_def_path }}"
+        name: crc_ci_bootstrap_networking
+
 - name: Create openstack config dir
   ansible.builtin.file:
     path: "{{ ansible_user_dir }}/.config/openstack/"

--- a/roles/bootstrap/tasks/create-attach-port.yml
+++ b/roles/bootstrap/tasks/create-attach-port.yml
@@ -16,7 +16,7 @@
 
 - name: Create the private network parent port
   vars:
-    default_net_fixed_ip: "{{ instance_item.value.networks.default.ip }}"
+    default_net_fixed_ip: "{{ instance_item.value.networks.default.ip_v4 }}"
   openstack.cloud.port:
     name: "{{ instance_item.key }}-{{ instance_id }}"
     network: "{{ crc_ci_bootstrap_private_net_create_yaml.network.id }}"
@@ -61,7 +61,6 @@
         )
     )
   changed_when: crc_ci_bootstrap_instance_trunk_creation_out.rc == 0
-
 
 - name: Print the host networking data
   when: crc_ci_bootstrap_instance_nm_vlan_networks | length > 0
@@ -116,7 +115,7 @@
       }}
     ip_with_prefix: >-
       {{
-        instance_item.value.networks.default.ip + "/" +
+        instance_item.value.networks.default.ip_v4 + "/" +
         (crc_ci_bootstrap_instance_default_net_config.range | ansible.utils.ipaddr('prefix') | string)
       }}
     ip_gateway: >-
@@ -153,6 +152,18 @@
             }
           }, recursive=true)
       }}
+    ci_bootstrap_networks_interfaces_out: >-
+      {{
+        ci_bootstrap_networks_interfaces_out |
+        default({}) |
+        combine(
+          {
+            instance_item.key: {
+              'mac': crc_ci_bootstrap_instance_parent_port_create_yaml.port.mac_address | lower,
+              'network': 'default'
+            }
+          }, recursive=true)
+      }}
     cacheable: true
 
 - name: Port attach details
@@ -179,19 +190,19 @@
             community.general.random_mac(
               seed=(
                   (crc_ci_bootstrap_instance_parent_port_create_yaml.port.mac_address | lower) +
-                  (network_config.vlan | string)
+                  (network_config.vlan_id | string)
                 )
             ) | lower
           }}
-        iface_name: "{{ parent_net_info.iface + '.' + (network_config.vlan | string) }}"
+        iface_name: "{{ parent_net_info.iface + '.' + (network_config.vlan_id | string) }}"
         # VLAN iface MTU is the parent MTU minus the 802.1Q header size
         iface_mtu: "{{ parent_net_info.mtu | int - 4 }}"
         ip_with_prefix: >-
           {{
-            instance_net_item.value.ip + "/" +
-            (network_config.range | ansible.utils.ipaddr('prefix') | string)
+            instance_net_item.value.ip_v4 + "/" +
+            (network_config.network_v4 | ansible.utils.ipaddr('prefix') | string)
           }}
-        iface_connection_name: "{{ 'ci-private-network-' + (network_config.vlan | string) }}"
+        iface_connection_name: "{{ 'ci-private-network-' + (network_config.vlan_id | string) }}"
       ansible.builtin.set_fact:
         crc_ci_bootstrap_networks_out: >-
           {{
@@ -201,18 +212,18 @@
                 instance_item.key: {
                   instance_net_item.key: {
                     'iface': iface_name,
-                    'vlan': network_config.vlan,
+                    'vlan': network_config.vlan_id,
                     'parent_iface': parent_net_info.iface,
                     'connection':
                       (
                         iface_connection_name
-                        if (instance_net_item.value.config_nm | default(true) | bool)
+                        if (not instance_net_item.value.skip_nm | default(false) | bool)
                         else omit
                       ),
                     'mac': iface_mac,
                     'mtu': iface_mtu,
                     'ip': ip_with_prefix,
-                    'dns': network_config.dns | default(omit),
+                    'dns': network_config.dns_v4 | default(omit),
                   }
                 }
               }, recursive=true)

--- a/roles/bootstrap/tasks/create-default-resources.yml
+++ b/roles/bootstrap/tasks/create-default-resources.yml
@@ -27,7 +27,7 @@
     state: present
     network_name: "{{ crc_ci_bootstrap_private_net_create_out.network.id }}"
     name: "{{ crc_ci_bootstrap_subnet_name }}"
-    cidr: "{{ default_network_config.range }}"
+    cidr: "{{ default_network_config.network_v4 }}"
     enable_dhcp: false
   register: crc_ci_bootstrap_private_subnet_create_out
 
@@ -43,7 +43,7 @@
     - name: Create router
       openstack.cloud.router:
         name: "{{ crc_ci_bootstrap_router_name }}"
-        network: "{{ default_network_config.router_net | default('public') }}"
+        network: "{{ default_network_config.router_net | default(cifmw_bootstrap_network_default_router_net) }}"
         interfaces:
           - "{{ crc_ci_bootstrap_private_subnet_create_out.subnet.id }}"
       register: crc_ci_bootstrap_private_router_create_out

--- a/roles/bootstrap/tasks/in_zuul.yml
+++ b/roles/bootstrap/tasks/in_zuul.yml
@@ -14,13 +14,24 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Debug parameters
-  ansible.builtin.debug:
-    var: crc_ci_bootstrap_networking
-
 # todo
 # - name: Validate the input data
 #   ansible.builtin.import_tasks: network-validate.yml
+
+- name: Load network environment definition from file
+  when: "crc_ci_bootstrap_networking is not defined or 
+         crc_ci_bootstrap_networking | length == 0"
+  block:
+    - name: Check for network environment definition file
+      ansible.builtin.stat:
+        path: "{{ cifmw_bootstrap_net_env_def_path }}"
+      register: _net_env_file_stat
+
+    - name: Load network info from file
+      when: "_net_env_file_stat.stat.exists"
+      ansible.builtin.include_vars:
+        file: "{{ cifmw_bootstrap_net_env_def_path }}"
+        name: crc_ci_bootstrap_networking
 
 - name: Create openstack config dir
   ansible.builtin.file:
@@ -124,6 +135,19 @@
       delegate_to: "{{ item }}"
       ansible.builtin.copy:
         dest: /etc/ci/env/networking-info.yml
+        content: "{{ content | to_nice_yaml }}"
+        owner: root
+        group: root
+        mode: '0644'
+      loop: "{{ hostvars.keys() }}"
+
+    - name: Save networking interface info for the mapper
+      vars:
+        content: "{{ crc_ci_bootstrap_networks_out | default({}) }}"
+      become: true
+      delegate_to: "{{ item }}"
+      ansible.builtin.copy:
+        dest: /etc/ci/env/ci-bootstrap-network-interfaces.yml
         content: "{{ content | to_nice_yaml }}"
         owner: root
         group: root

--- a/roles/bootstrap/tasks/instance-add-vlan.yml
+++ b/roles/bootstrap/tasks/instance-add-vlan.yml
@@ -20,7 +20,7 @@
 
 - name: "Create the VLAN port for instance: {{ instance_item.key }}"
   vars:
-    vlan_tag: "{{ crc_ci_bootstrap_networking.networks[instance_net_item.key].vlan }}"
+    vlan_tag: "{{ crc_ci_bootstrap_networking.networks[instance_net_item.key].vlan_id }}"
   openstack.cloud.port:
     name: "{{ instance_item.key }}-{{ instance_id }}-{{ vlan_tag }}"
     network: "{{ crc_ci_bootstrap_private_net_create_yaml.id }}"
@@ -28,8 +28,8 @@
 
 - name: "Add the VLAN port to the trunk for instance: {{ instance_item.key }}"
   vars:
-    vlan_id: "{{ crc_ci_bootstrap_networking.networks[instance_net_item.key].vlan }}"
-    port_id: "{{ instance_item.key }}-{{ instance_id }}-{{ crc_ci_bootstrap_networking.networks[instance_net_item.key].vlan }}"
+    vlan_id: "{{ crc_ci_bootstrap_networking.networks[instance_net_item.key].vlan_id }}"
+    port_id: "{{ instance_item.key }}-{{ instance_id }}-{{ crc_ci_bootstrap_networking.networks[instance_net_item.key].vlan_id }}"
     parent_port_id: "zuul-ci-trunk-{{ instance_item.key }}-{{ instance_id }}"
   ansible.builtin.command:
     cmd: >-


### PR DESCRIPTION
To start using networking mapper, we will need to consume the network environment definition which has some minor differences on its dictionary. This role now also generates another interfaces file that will be used by the mapper again.