### PR TITLE
Fix network interface for OCP 4.14 nmstate (#28)

### DIFF
--- a/roles/bootstrap/templates/bootstrap-ci-network-nm-connection.nmconnection.j2
+++ b/roles/bootstrap/templates/bootstrap-ci-network-nm-connection.nmconnection.j2
@@ -3,6 +3,7 @@ id={{ iface_info.connection }}
 uuid={{ 99999999 | random | to_uuid }}
 type=ethernet
 autoconnect=true
+interface-name={{ iface_info.iface }}
 
 [ethernet]
 mac-address={{ iface_info.mac | trim | lower }}

--- a/roles/bootstrap/templates/bootstrap-ci-network-vlan-nm-connection.nmconnection.j2
+++ b/roles/bootstrap/templates/bootstrap-ci-network-vlan-nm-connection.nmconnection.j2
@@ -3,6 +3,7 @@ id={{ iface_info.connection }}
 uuid={{ 99999999 | random | to_uuid }}
 type=vlan
 autoconnect=true
+interface-name={{ iface_info.parent_iface }}.{{ iface_info.vlan }}
 
 [ethernet]
 cloned-mac-address={{ iface_info.mac | trim | lower }}


### PR DESCRIPTION
With the upgrade to OCP 4.14 nmstate expects interfaces `connection.interface-name` be set. Without this parameter set, nmstate rather than overriding the existing networks we create in the bootstrap phase, will create duplicate interfaces creating many networking issues and EDPM network connectivity.

Testing here: https://review.rdoproject.org/r/c/testproject/+/48840

JIRA: OSPRH-4077