### PR TITLE
Set trunk interface to never-default=true

### DIFF
--- a/roles/bootstrap/templates/bootstrap-ci-network-nm-connection.nmconnection.j2
+++ b/roles/bootstrap/templates/bootstrap-ci-network-nm-connection.nmconnection.j2
@@ -11,6 +11,7 @@ mtu={{ iface_info.mtu }}
 [ipv4]
 method=manual
 addresses={{ iface_info.ip }}
+never-default=true
 {% if iface_info.gw is defined and iface_info.gw != '' -%}
 gateway={{ iface_info.gw }}
 {% endif -%}


### PR DESCRIPTION
This change tells network manager not to create a second default route. This is needed because currently when nmstate runs later as part of the openstack run, the second route (ens7) is removed and nmstate probe fails causing the NNCP to fail on the ping probe.

The second default route shouldn't be here from the creation of the interface and this patch resolved that.

Before:
```
[core@crc-pjmnl-master-0 ~]$ ip r
default via 10.0.199.254 dev ens3 proto dhcp src 10.0.199.189 metric 100
default via 192.168.122.1 dev ens7 proto static metric 101
```

After:
```
[core@crc-pjmnl-master-0 ~]$ ip r
default via 10.0.199.254 dev ens3 proto dhcp src 10.0.199.189 metric 100
```