### PR TITLE
Fix non_zuul_cleanup + openstacksdk in locale/injected +make  _ifaces_out recursively merged.

### DIFF
--- a/roles/bootstrap/tasks/configure-guest-networking.yml
+++ b/roles/bootstrap/tasks/configure-guest-networking.yml
@@ -165,7 +165,7 @@
 - name: Apply Network Manager changes in the target instance
   delegate_to: "{{ instance_item.key }}"
   block:
-    - name: Create NetworkManager configuration file for the trunk port
+    - name: Create NetworkManager configuration file
       vars:
         iface_info: "{{ item.value }}"
       become: true

--- a/roles/bootstrap/tasks/configure-guest-networking.yml
+++ b/roles/bootstrap/tasks/configure-guest-networking.yml
@@ -48,7 +48,7 @@
                 ) | first
             }
           }
-        )
+        , recursive=true)
       }}
   when: item.skipped is not defined
   loop: "{{ ci_bootstrap_instance_wait_device_up_out.results }}"

--- a/roles/bootstrap/tasks/controller-pre.yml
+++ b/roles/bootstrap/tasks/controller-pre.yml
@@ -48,12 +48,20 @@
   ansible.builtin.include_role:
     name: prepare-workspace
 
-- name: Install packeges
+- name: Install packages
   become: true
   ansible.builtin.package:
     name:
       - python3-pip
     state: present
+
+# NOTE(hjensas): There is an issue with collection module not using the virtualenv,
+# so we need to install openstacksdk in the user local.
+- name: Install openstacksdk (outside virtualenv)
+  when: "'local' in ansible_run_tags or 'inject' in ansible_run_tags"
+  ansible.builtin.pip:
+    name:
+      - "openstacksdk"
 
 - name: Install ansible in virtualenv
   ansible.builtin.pip:
@@ -64,9 +72,10 @@
       - "openstacksdk"
       - "ansible-core"
 
-- name: Ensure Ansible galaxy collections are installed in the venv
-  ansible.builtin.shell: |
-    {{ cifmw_bootstrap_venv_dir }}/bin/ansible-galaxy collection install {{ item }}
+- name: Ensure Ansible galaxy collections are installed
+  ansible.builtin.command:
+    cmd: >-
+      {{ cifmw_bootstrap_venv_dir }}/bin/ansible-galaxy collection install {{ item }}
   loop:
     - openstack.cloud
 

--- a/roles/bootstrap/tasks/non_zuul_cleanup.yml
+++ b/roles/bootstrap/tasks/non_zuul_cleanup.yml
@@ -19,27 +19,31 @@
     file: "{{ cifmw_bootstrap_clouds_yaml }}"
     name: clouds_yaml
 
-- name: Cleanup instances
-  openstack.cloud.server:
-    state: absent
-    name: "{{ item.key }}-cifmw"
-  loop: "{{ cifmw_bootstap_local_instances | dict2items }}"
-  tags: create_resources
-
-- name: Cleanup resources
+- name: Cleanup cloud resources
   environment:
     OS_CLOUD: "{{ cifmw_bootstrap_cloud_name }}"
-  tags: cleanup_resources
   block:
-    - name: Delete keypair
-      openstack.cloud.keypair:
+    - name: Cleanup instances
+      openstack.cloud.server:
         state: absent
-        name: "{{ cifmw_bootstrap_keypair_name }}"
+        name: "{{ item.key }}-cifmw"
+      loop: "{{ cifmw_bootstap_local_instances | dict2items }}"
+      tags: create_resources
 
-    - name: Delete SG
-      openstack.cloud.security_group:
-        state: absent
-        name: "{{ cifmw_bootstrap_security_group_name }}"
+    - name: Cleanup resources
+      environment:
+        OS_CLOUD: "{{ cifmw_bootstrap_cloud_name }}"
+      tags: cleanup_resources
+      block:
+        - name: Delete keypair
+          openstack.cloud.keypair:
+            state: absent
+            name: "{{ cifmw_bootstrap_keypair_name }}"
+
+        - name: Delete SG
+          openstack.cloud.security_group:
+            state: absent
+            name: "{{ cifmw_bootstrap_security_group_name }}"
 
 - name: Cleanup inventory
   ansible.builtin.file:


### PR DESCRIPTION
# Build _ifaces_out using recursive combine
    
In a scenario where either multiple ports and no vlan trunks are used, or if multiple trunk ports with vlans are used the _ifaces_out map must be recursively merged.
    
The result should be:
```
      instance-name:
        net-a: $IFACE_OUT
        net-b: $IFACE_OUT
```

# Install openstacksdk in users local env
Something is not quite right with the openstack.cloud collection, it does not look in the virtualenv for openstacksdk. Workaround this by pip installing openstacksdk in the users.

It seems in CI something else is installing the openstacksdk, so the task to install it in users local env is conditioned on the 'local' or 'inject' tag being used.

# Fix non_zuul_cleanup

Make sure the OS_CLOUD environment is set.