### PR TITLE
Fix additional skip_nm: true issues

### DIFF
--- a/roles/bootstrap/tasks/configure-guest-networking.yml
+++ b/roles/bootstrap/tasks/configure-guest-networking.yml
@@ -169,7 +169,6 @@
       vars:
         iface_info: "{{ item.value }}"
       become: true
-      when: "iface_info.connection is defined and iface_info.connection != ''"
       ansible.builtin.template:
         src: >-
           {{
@@ -180,7 +179,7 @@
         mode: '0600'
         owner: root
         group: root
-      loop: "{{ crc_ci_bootstrap_networks_out[instance_item.key] | dict2items }}"
+      loop: "{{ crc_ci_bootstrap_networks_out[instance_item.key] | default({}) | dict2items }}"
       loop_control:
         label: "{{ item.key }}"
 


### PR DESCRIPTION
If all networks on a node has skip_nm: true there will be no data in the crc_ci_bootstrap_networks_out map for that node.

This change defaults it to an empty dict in that case.

Also remove the condition on connection, it should not be needed.