### PR TITLE
Add required projects in the staging job

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -3,4 +3,23 @@
     name: openstack-k8s-operators/ci-bootstrap
     github-post:
       jobs:
-        - podified-multinode-edpm-deployment-crc-bootstrap-staging
+        - podified-multinode-edpm-deployment-crc-bootstrap-staging:
+            required-projects:
+              - name: openstack-k8s-operators/ci-framework
+                override-checkout: main
+              - name: openstack-k8s-operators/dataplane-operator
+                override-checkout: main
+              - name: openstack-k8s-operators/install_yamls
+                override-checkout: main
+              - name: openstack-k8s-operators/infra-operator
+                override-checkout: main
+              - name: openstack-k8s-operators/openstack-baremetal-operator
+                override-checkout: main
+              - name: openstack-k8s-operators/openstack-must-gather
+                override-checkout: main
+              - name: openstack-k8s-operators/openstack-operator
+                override-checkout: main
+              - name: openstack-k8s-operators/repo-setup
+                override-checkout: main
+              - name: openstack-k8s-operators/edpm-ansible
+                override-checkout: main


### PR DESCRIPTION
It will fix following error coming in these jobs
https://review.rdoproject.org/zuul/builds?pipeline=github-post&skip=0
```
Error: Project github.com/openstack-k8s-operators/dataplane-operator does not have the default branch master
```