### PR TITLE
Align resource names with cleanup script

### DIFF
--- a/roles/bootstrap/tasks/in_zuul/create-attach-ports.yml
+++ b/roles/bootstrap/tasks/in_zuul/create-attach-ports.yml
@@ -66,7 +66,7 @@
             and net.trunk_parent == net_item.key %}
       --subport port={{ ci_bootstrap_os_port_map[instance_item.key][net_name].id }},segmentation-type=vlan,segmentation-id={{ net.vlan_id }}
       {% endfor %}
-      {{ net_item.key }}-trunk-{{ instance_id }}
+      zuul-ci-trunk-{{ net_item.key }}-{{ instance_id }}
       -f value -c id
   register: _create_trunk
   when: net_item.value.is_trunk_parent | default(false)

--- a/roles/bootstrap/tasks/in_zuul/create-network-resources.yml
+++ b/roles/bootstrap/tasks/in_zuul/create-network-resources.yml
@@ -17,7 +17,7 @@
 - name: Create network
   openstack.cloud.network:
     state: present
-    name: "{{ network_item.key }}-cifmw-{{ zuul.build[:8] }}"
+    name: "zuul-ci-net-{{ network_item.key }}-cifmw-{{ zuul.build[:8] }}"
     port_security_enabled: false
   register: _network_out
 

--- a/roles/bootstrap/tasks/in_zuul/create-router.yml
+++ b/roles/bootstrap/tasks/in_zuul/create-router.yml
@@ -55,12 +55,12 @@
 - name: Create router
   when: router_item.value.external_network is defined
   openstack.cloud.router:
-    name: "cifmw-{{ router_item.key }}-{{ zuul.build[:8] }}"
+    name: "zuul-ci-router-{{ router_item.key }}-{{ zuul.build[:8] }}"
     network: "{{ router_item.value.external_network }}"
     interfaces: "{{ router_interfaces }}"
 
 - name: Create router (no external gateway network)
   when: router_item.value.external_network is not defined
   openstack.cloud.router:
-    name: "cifmw-{{ router_item.key }}-{{ zuul.build[:8] }}"
+    name: "zuul-ci-router-{{ router_item.key }}-{{ zuul.build[:8] }}"
     interfaces: "{{ router_interfaces }}"


### PR DESCRIPTION
Align names of resources with this cleanup script: https://softwarefactory-project.io/r/c/software-factory/sf-infra/+/31033/1/roles/next-gen/cleanup-openstack-resources/files/cleanup-ports-next-gen.sh