### PR TITLE
Create application credential and use them

### DIFF
--- a/roles/bootstrap/README.md
+++ b/roles/bootstrap/README.md
@@ -10,6 +10,7 @@ It supports OpenStack cloud as provider.
 * `cifmw_bootstrap_openstack_cmd_delay_value`: (Integer) Default delay value when retrying some openstack commands. Defaults to `5`.
 * `cifmw_bootstrap_ci_infra_dir`: (String) Directory where to search and save CI environment files. Default to `"/etc/ci/env"`.
 * `cifmw_bootstrap_net_env_def_path`: (String) Path to the network environment definition file. Defaults to `"{{ cifmw_bootstrap_ci_infra_dir }}/networking-environment-definition.yml"`
+* `cifmw_bootstrap_create_application_credential`: (Boolean) Whether to create application credentials and use them for all subsequent OpenStack operations. Defaults to `false`.
 
 ## TODO
 * Management of computes resources is not yet supported.

--- a/roles/bootstrap/defaults/main.yml
+++ b/roles/bootstrap/defaults/main.yml
@@ -29,3 +29,5 @@ cifmw_bootstrap_openstack_cmd_delay_value: "{{ crc_ci_bootstrap_openstack_cmd_de
 
 cifmw_bootstrap_ci_infra_dir: "/etc/ci/env"
 cifmw_bootstrap_net_env_def_path: "{{ cifmw_bootstrap_ci_infra_dir }}/networking-environment-definition.yml"
+
+cifmw_bootstrap_create_application_credential: false

--- a/roles/bootstrap/files/in_zuul_cleanup-playbook.yaml
+++ b/roles/bootstrap/files/in_zuul_cleanup-playbook.yaml
@@ -21,3 +21,8 @@
     ansible.builtin.include_role:
       name: bootstrap
       tasks_from: in_zuul/cleanup-networks.yml
+  - name: Clean up application credential
+    when: cifmw_bootstrap_create_application_credential | bool
+    ansible.builtin.include_role:
+      name: bootstrap
+      tasks_from: in_zuul/cleanup-application-credential.yml

--- a/roles/bootstrap/tasks/in_zuul.yml
+++ b/roles/bootstrap/tasks/in_zuul.yml
@@ -21,6 +21,10 @@
 - name: Load network environment definition from file
   ansible.builtin.include_tasks: load-input.yml
 
+- name: Replace cloud config with new application credential
+  when: cifmw_bootstrap_create_application_credential | bool
+  ansible.builtin.include_tasks: in_zuul/create-application-credential.yml
+
 - name: Create the crc based CI environment
   environment:
     OS_CLOUD: "{{ cifmw_bootstrap_cloud_name }}"

--- a/roles/bootstrap/tasks/in_zuul/cleanup-application-credential.yml
+++ b/roles/bootstrap/tasks/in_zuul/cleanup-application-credential.yml
@@ -1,0 +1,52 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Assert cifmw_bootstrap_cloud_name is defined
+  ansible.builtin.assert:
+    that:
+      - cifmw_bootstrap_cloud_name is defined
+    msg: "Cloud name is mandatory"
+    quiet: true
+
+- name: Clear application credential from cloud_secrets
+  ansible.utils.update_fact:
+    updates:
+      - path: "cloud_secrets.{{cifmw_bootstrap_cloud_name}}.auth_type"
+        value: password
+      - path: "cloud_secrets.{{cifmw_bootstrap_cloud_name}}.application_credential_id"
+        value:
+      - path: "cloud_secrets.{{cifmw_bootstrap_cloud_name}}.application_credential_secret"
+        value:
+  register: updated_cloud_secrets
+
+- name: Replace cloud_secrets with updated
+  ansible.builtin.set_fact:
+    cloud_secrets: "{{ updated_cloud_secrets.cloud_secrets }}"
+
+- name: Rewrite clouds.yaml file with original credential
+  ansible.builtin.template:
+    src: clouds.yaml.j2
+    dest: "{{ cifmw_bootstrap_clouds_yaml }}"
+    mode: "0600"
+
+- name: Delete application credential
+  # TODO(sbaker) Replace with openstack.cloud.application_credential when [1] is consumable,
+  # also revert [2].
+  # [1] https://review.opendev.org/c/openstack/ansible-collections-openstack/+/910463
+  # [2] https://github.com/openstack-k8s-operators/ci-framework/commit/d564775c414e14ec25b62d05a3d477f9303e5be0
+  application_credential:
+    name: "cifmw-bootstrap-{{ zuul.build }}"
+    state: absent

--- a/roles/bootstrap/tasks/in_zuul/create-application-credential.yml
+++ b/roles/bootstrap/tasks/in_zuul/create-application-credential.yml
@@ -1,0 +1,53 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Assert cifmw_bootstrap_cloud_name is defined
+  ansible.builtin.assert:
+    that:
+      - cifmw_bootstrap_cloud_name is defined
+    msg: "Cloud name is mandatory"
+    quiet: true
+
+- name: Create application credential
+  # TODO(sbaker) Replace with openstack.cloud.application_credential when [1] is consumable,
+  # also revert [2].
+  # [1] https://review.opendev.org/c/openstack/ansible-collections-openstack/+/910463
+  # [2] https://github.com/openstack-k8s-operators/ci-framework/commit/d564775c414e14ec25b62d05a3d477f9303e5be0
+  application_credential:
+    name: "cifmw-bootstrap-{{ zuul.build }}"
+    # TODO(sbaker) Ideally expires_at will be set to the job timeout, if that is available here
+  register: cifmw_bootstrap_appcred
+
+- name: Update cloud_secrets with application credential
+  ansible.utils.update_fact:
+    updates:
+      - path: "cloud_secrets.{{cifmw_bootstrap_cloud_name}}.auth_type"
+        value: "v3applicationcredential"
+      - path: "cloud_secrets.{{cifmw_bootstrap_cloud_name}}.application_credential_id"
+        value: "{{ cifmw_bootstrap_appcred.application_credential.id }}"
+      - path: "cloud_secrets.{{cifmw_bootstrap_cloud_name}}.application_credential_secret"
+        value: "{{ cifmw_bootstrap_appcred.application_credential.secret }}"
+  register: updated_cloud_secrets
+
+- name: Replace cloud_secrets with updated
+  ansible.builtin.set_fact:
+    cloud_secrets: "{{ updated_cloud_secrets.cloud_secrets }}"
+
+- name: Rewrite clouds.yaml file with application credential
+  ansible.builtin.template:
+    src: clouds.yaml.j2
+    dest: "{{ cifmw_bootstrap_clouds_yaml }}"
+    mode: "0600"


### PR DESCRIPTION
This change adds the variable
cifmw_bootstrap_create_application_credential. When set to true, an application credential will be created and subsequent OpenStack operations will use these credentials.

This will allow the contents of clouds.yaml to be inserted into a crc secret so that a sushy-tools pod can use them to managed nodepool resources. This will eventually allow full multi node baremetal jobs where EDPM nodes are nodepool vms which can be managed as virtual baremetal.

Issue: OSPRH-5579
Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1296