### PR TITLE
Add ssh_user to cifmw_bootstap_local_instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,24 +37,28 @@ Example `my_vars.yml` for local testing:
 local_net_env_def: networking-environment-definition.yml
 cifmw_bootstap_local_instances:
   controller:
+    ssh_user: cloud-user
     flavor: m1.large
     image: CentOS-Stream-GenericCloud-9
     keypair: "{{ cifmw_bootstrap_keypair_name }}"
     security_group: "{{ cifmw_bootstrap_security_group_name }}"
     network: private
   crc:
+    ssh_user: core
     flavor: m1.xlarge
     image: crc-image
     keypair: "{{ cifmw_bootstrap_keypair_name }}"
     security_group: "{{ cifmw_bootstrap_security_group_name }}"
     network: private
   compute-0:
+    ssh_user: cloud-user
     flavor: m1.large
     image: CentOS-Stream-GenericCloud-9
     keypair: "{{ cifmw_bootstrap_keypair_name }}"
     security_group: "{{ cifmw_bootstrap_security_group_name }}"
     network: private
   compute-1:
+    ssh_user: cloud-user
     flavor: m1.large
     image: CentOS-Stream-GenericCloud-9
     keypair: "{{ cifmw_bootstrap_keypair_name }}"

--- a/roles/bootstrap/tasks/create-instance.yml
+++ b/roles/bootstrap/tasks/create-instance.yml
@@ -33,7 +33,7 @@
 - name: Add to Ansible inventory "{{ instance_name }}"
   ansible.builtin.add_host:
     name: "{{ instance_name }}"
-    ansible_ssh_user: cloud-user
+    ansible_ssh_user: "{{ instance_ssh_user | default("cloud-user") }}"
     ansible_host: "{{ server_info.servers[0].access_ipv4 }}"
     groups: nodepool
     nodepool: { 'external_id': "{{ result.server.id }}" }

--- a/roles/bootstrap/tasks/non_zuul.yml
+++ b/roles/bootstrap/tasks/non_zuul.yml
@@ -32,6 +32,7 @@
     create-instance.yml
   vars:
     instance_name: "{{ item.key }}"
+    instance_ssh_user: "{{ item.value.ssh_user }}"
     instance_flavor: "{{ item.value.flavor }}"
     instance_image: "{{ item.value.image }}"
     instance_keypair: "{{ item.value.keypair }}"


### PR DESCRIPTION
Add the `ssh_user` option to local instances. If we deploy an actual CRC node locally we need to set ssh user `core` for this instance.

The ssh_user is set used for `ansible_ssh_user` in the inventory and defaults to `cloud-user`.