### PR TITLE
Remove dataplane-operator references

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -7,8 +7,6 @@
             required-projects:
               - name: openstack-k8s-operators/ci-framework
                 override-checkout: main
-              - name: openstack-k8s-operators/dataplane-operator
-                override-checkout: main
               - name: openstack-k8s-operators/install_yamls
                 override-checkout: main
               - name: openstack-k8s-operators/infra-operator


### PR DESCRIPTION
The dataplane-operator is no longer
used as a standalone repo inclusion.