### PR TITLE
Add missing vars to in_zuul-vars file

### DIFF
--- a/roles/bootstrap/tasks/controller-pre.yml
+++ b/roles/bootstrap/tasks/controller-pre.yml
@@ -137,6 +137,7 @@
       nodepool_instance_id_map: "{{ nodepool_instance_id_map }}"
       cifmw_bootstrap_cloud_name: "{{ cifmw_bootstrap_cloud_name }}"
       cifmw_bootstrap_net_name_prefix: "{{ cifmw_bootstrap_net_name_prefix }}"
+      cifmw_bootstrap_create_application_credential: "{{ cifmw_bootstrap_create_application_credential }}"
   become: true
   ansible.builtin.copy:
     dest: /etc/ci/env/in_zuul-vars.yml


### PR DESCRIPTION
When calling the network clenaup, the nested call to the
in_zuul_cleanup-playbook.yaml playbook fails because
cifmw_bootstrap_create_application_credential is not  defined, even
though it has a default in the role. This change adds it to the
in_zuul-vars.yaml file so that it can be exposed to the nested playbook.
