### PR TITLE
Do not render the entire zuul var if only the build ID is needed

### DIFF
--- a/infra-bootstrap.yml
+++ b/infra-bootstrap.yml
@@ -23,8 +23,7 @@
   tasks:
     - name: Set zuul var
       ansible.builtin.set_fact:
-        zuul:
-          build: 1dcaf86e72ec4400a8012f3892d815be
+        cifmw_bootstrap_build_id: 1dcaf86e72ec4400a8012f3892d815be
     - name: Run tasks/non_zuul instead of 'main'
       ansible.builtin.include_role:
         name: bootstrap
@@ -112,8 +111,8 @@
   tasks:
     - name: Set zuul var
       ansible.builtin.set_fact:
-        zuul:
-          build: 1dcaf86e72ec4400a8012f3892d815be
+        cifmw_bootstrap_build_id: 1dcaf86e72ec4400a8012f3892d815be
+
     - name: Copy network-environment-definition to controller
       when: local_net_env_def is defined
       become: true

--- a/roles/bootstrap/tasks/controller-pre.yml
+++ b/roles/bootstrap/tasks/controller-pre.yml
@@ -132,7 +132,7 @@
     content:
       cifmw_bootstrap_net_env_def_path: "{{ cifmw_bootstrap_net_env_def_path }}"
       cifmw_bootstrap_ci_infra_dir: "{{ cifmw_bootstrap_ci_infra_dir }}"
-      zuul: "{{ zuul }}"
+      cifmw_bootstrap_build_id: "{{ zuul.build }}"
       cifmw_bootstrap_venv_dir: "{{ cifmw_bootstrap_venv_dir }}"
       nodepool_instance_id_map: "{{ nodepool_instance_id_map }}"
       cifmw_bootstrap_cloud_name: "{{ cifmw_bootstrap_cloud_name }}"

--- a/roles/bootstrap/tasks/in_zuul/cleanup-application-credential.yml
+++ b/roles/bootstrap/tasks/in_zuul/cleanup-application-credential.yml
@@ -48,5 +48,5 @@
   # [1] https://review.opendev.org/c/openstack/ansible-collections-openstack/+/910463
   # [2] https://github.com/openstack-k8s-operators/ci-framework/commit/d564775c414e14ec25b62d05a3d477f9303e5be0
   application_credential:
-    name: "cifmw-bootstrap-{{ zuul.build }}"
+    name: "cifmw-bootstrap-{{ cifmw_bootstrap_build_id }}"
     state: absent

--- a/roles/bootstrap/tasks/in_zuul/cleanup-networks.yml
+++ b/roles/bootstrap/tasks/in_zuul/cleanup-networks.yml
@@ -5,7 +5,7 @@
 
 - name: Get the networks
   openstack.cloud.networks_info:
-    name: "{{ cifmw_bootstrap_net_name_prefix }}-{{ network_item.key }}-cifmw-{{ zuul.build[:8] }}"
+    name: "{{ cifmw_bootstrap_net_name_prefix }}-{{ network_item.key }}-cifmw-{{ cifmw_bootstrap_build_id[:8] }}"
   register: _networks_out
   loop: "{{ crc_ci_bootstrap_networking.networks | dict2items }}"
   loop_control:

--- a/roles/bootstrap/tasks/in_zuul/create-application-credential.yml
+++ b/roles/bootstrap/tasks/in_zuul/create-application-credential.yml
@@ -27,7 +27,7 @@
   # [1] https://review.opendev.org/c/openstack/ansible-collections-openstack/+/910463
   # [2] https://github.com/openstack-k8s-operators/ci-framework/commit/d564775c414e14ec25b62d05a3d477f9303e5be0
   application_credential:
-    name: "cifmw-bootstrap-{{ zuul.build }}"
+    name: "cifmw-bootstrap-{{ cifmw_bootstrap_build_id }}"
     # TODO(sbaker) Ideally expires_at will be set to the job timeout, if that is available here
   register: cifmw_bootstrap_appcred
 

--- a/roles/bootstrap/tasks/in_zuul/create-network-resources.yml
+++ b/roles/bootstrap/tasks/in_zuul/create-network-resources.yml
@@ -17,7 +17,7 @@
 - name: Create network
   openstack.cloud.network:
     state: present
-    name: "{{ cifmw_bootstrap_net_name_prefix }}-{{ network_item.key }}-cifmw-{{ zuul.build[:8] }}"
+    name: "{{ cifmw_bootstrap_net_name_prefix }}-{{ network_item.key }}-cifmw-{{ cifmw_bootstrap_build_id[:8] }}"
     port_security_enabled: false
   register: _network_out
 
@@ -26,7 +26,7 @@
   openstack.cloud.subnet:
     state: present
     network_name: "{{ _network_out.network.id }}"
-    name: "{{ network_item.key }}-subnet-cifmw-{{ zuul.build[:8] }}"
+    name: "{{ network_item.key }}-subnet-cifmw-{{ cifmw_bootstrap_build_id[:8] }}"
     cidr: "{{ network_item.value.network_v4 }}"
     gateway_ip: "{{ network_item.value.gw_v4 | default(none) }}"
     dns_nameservers: "{{ network_item.value.dns_v4 }}"
@@ -37,7 +37,7 @@
   openstack.cloud.subnet:
     state: present
     network_name: "{{ _network_out.network.id }}"
-    name: "{{ network_item.key }}-subnet-cifmw-{{ zuul.build[:8] }}"
+    name: "{{ network_item.key }}-subnet-cifmw-{{ cifmw_bootstrap_build_id[:8] }}"
     cidr: "{{ network_item.value.network_v4 }}"
     dns_nameservers: "{{ network_item.value.dns_v4 }}"
     enable_dhcp: false
@@ -58,5 +58,5 @@
           {
             network_item.key: {'network': _network_info_out.networks | first},
           }
-        ) 
+        )
       }}

--- a/roles/bootstrap/tasks/in_zuul/create-router.yml
+++ b/roles/bootstrap/tasks/in_zuul/create-router.yml
@@ -55,12 +55,12 @@
 - name: Create router
   when: router_item.value.external_network is defined
   openstack.cloud.router:
-    name: "zuul-ci-router-{{ router_item.key }}-{{ zuul.build[:8] }}"
+    name: "zuul-ci-router-{{ router_item.key }}-{{ cifmw_bootstrap_build_id[:8] }}"
     network: "{{ router_item.value.external_network }}"
     interfaces: "{{ router_interfaces }}"
 
 - name: Create router (no external gateway network)
   when: router_item.value.external_network is not defined
   openstack.cloud.router:
-    name: "zuul-ci-router-{{ router_item.key }}-{{ zuul.build[:8] }}"
+    name: "zuul-ci-router-{{ router_item.key }}-{{ cifmw_bootstrap_build_id[:8] }}"
     interfaces: "{{ router_interfaces }}"


### PR DESCRIPTION
We were rendering into a file the entire zuul variable that may contain jinja templates not yet resolved only because we needed the zuul.build field and it was convenient.